### PR TITLE
Fix rendering of void elements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "25.2"
-          gleam-version: "0.32.2"
+          gleam-version: "0.34.1"
           rebar3-version: "3"
       - run: gleam format --check src test
       - run: gleam deps download

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- [Void elements](https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element)
+  are now rendered correctly ([#2](https://github.com/lpil/htmb/pull/2))
+
 ## v1.1.0 - 2023-11-06
 
 - Updated for Gleam v0.32.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
-
+- **[BREAKING]** The package now exclusively targets HTML5 and `render_page` no
+  longer accepts the `doctype` parameter
+  ([#2](https://github.com/lpil/htmb/pull/2))
 - [Void elements](https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element)
   are now rendered correctly ([#2](https://github.com/lpil/htmb/pull/2))
 

--- a/src/htmb.gleam
+++ b/src/htmb.gleam
@@ -86,9 +86,9 @@ fn do_escape(escaped: String, content: String) -> String {
   }
 }
 
-pub fn render_page(html: Html, doctype doctype: String) -> StringBuilder {
+pub fn render_page(html: Html) -> StringBuilder {
   render(html)
-  |> string_builder.prepend("<!DOCTYPE " <> doctype <> ">")
+  |> string_builder.prepend("<!DOCTYPE html>")
 }
 
 fn attribute(content: String, attribute: #(String, String)) -> String {

--- a/src/htmb.gleam
+++ b/src/htmb.gleam
@@ -30,13 +30,38 @@ pub fn h(
   attributes: List(#(String, String)),
   children: List(Html),
 ) -> Html {
-  "<"
-  |> string.append(tag)
-  |> list.fold(attributes, _, attribute)
-  |> string.append(">")
-  |> string_builder.from_string
-  |> list.fold(children, _, child)
-  |> string_builder.append("</" <> tag <> ">")
+  let opening =
+    "<"
+    |> string.append(tag)
+    |> list.fold(attributes, _, attribute)
+    |> string.append(">")
+    |> string_builder.from_string
+
+  // Void elements do not have a closing part and cannot accept children
+  // See https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#syntax-elements
+  case tag {
+    // See https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-elements
+    "area"
+    | "base"
+    | "br"
+    | "col"
+    | "command"
+    | "embed"
+    | "hr"
+    | "img"
+    | "input"
+    | "keygen"
+    | "link"
+    | "meta"
+    | "param"
+    | "source"
+    | "track"
+    | "wbr" -> opening
+    _ ->
+      opening
+      |> list.fold(children, _, child)
+      |> string_builder.append("</" <> tag <> ">")
+  }
   |> dangerous_unescaped_fragment
 }
 

--- a/test/htmb_test.gleam
+++ b/test/htmb_test.gleam
@@ -34,7 +34,7 @@ pub fn page_test() {
       h("script", [], [text("console.log('Hello, Joe!');")]),
     ]),
   ])
-  |> htmb.render_page(doctype: "html")
+  |> htmb.render_page
   |> string_builder.to_string
   |> should.equal(
     "<!DOCTYPE html><html lang=\"en\"><head><title>htmb test</title><meta charset=\"utf-8\"></head><body><h1>Hello, Joe!</h1><script>console.log('Hello, Joe!');</script></body></html>",

--- a/test/htmb_test.gleam
+++ b/test/htmb_test.gleam
@@ -14,33 +14,30 @@ pub fn hello_joe_test() {
   |> should.equal("<h1>Hello Joe!</h1>")
 }
 
+pub fn void_test() {
+  h("img", [#("src", "/tilly.jpg"), #("alt", "A perfect cat")], [
+    text("Will not show up!"),
+  ])
+  |> htmb.render
+  |> string_builder.to_string
+  |> should.equal("<img src=\"/tilly.jpg\" alt=\"A perfect cat\">")
+}
+
 pub fn page_test() {
-  h(
-    "html",
-    [#("lang", "en")],
-    [
-      h(
-        "head",
-        [],
-        [
-          h("title", [], [text("htmb test")]),
-          h("meta", [#("charset", "utf-8")], []),
-        ],
-      ),
-      h(
-        "body",
-        [],
-        [
-          h("h1", [], [text("Hello, Joe!")]),
-          h("script", [], [text("console.log('Hello, Joe!');")]),
-        ],
-      ),
-    ],
-  )
+  h("html", [#("lang", "en")], [
+    h("head", [], [
+      h("title", [], [text("htmb test")]),
+      h("meta", [#("charset", "utf-8")], []),
+    ]),
+    h("body", [], [
+      h("h1", [], [text("Hello, Joe!")]),
+      h("script", [], [text("console.log('Hello, Joe!');")]),
+    ]),
+  ])
   |> htmb.render_page(doctype: "html")
   |> string_builder.to_string
   |> should.equal(
-    "<!DOCTYPE html><html lang=\"en\"><head><title>htmb test</title><meta charset=\"utf-8\"></meta></head><body><h1>Hello, Joe!</h1><script>console.log('Hello, Joe!');</script></body></html>",
+    "<!DOCTYPE html><html lang=\"en\"><head><title>htmb test</title><meta charset=\"utf-8\"></head><body><h1>Hello, Joe!</h1><script>console.log('Hello, Joe!');</script></body></html>",
   )
 }
 


### PR DESCRIPTION
Fixes #1. Note that this doesn't embed the fact that children of void elements are discarded/unused into the types--I figured that the friction for a developer of having to remember which elements are void feels a bit...trivia-esque. Open to other thoughts though!